### PR TITLE
Gerrit -> Bugzilla: support "Task-Url: https://..." in footer

### DIFF
--- a/gerrit_to_bugzilla.pl
+++ b/gerrit_to_bugzilla.pl
@@ -106,7 +106,7 @@ while (<STDIN>) {
         if($subject =~ m/([Bb]ug:?\s*#?)(\d+)/) {
                 $bug_id = $2;
         }
-        if($_ =~ m#^Bug: (?:https://bugs\.\w+\.org/(?:bugs/show_bug\.cgi\?id=)?)?(\d+)#) {
+        if($_ =~ m#^(?:Bug|Task-Url): (?:https://bugs\.\w+\.org/(?:bugs/show_bug\.cgi\?id=)?)?(\d+)#) {
                 $bug_id = $1;
         }
         if($_ =~ m/^Gerrit-Branch: ([a-zA-Z0-9\/\._-]+)/) {


### PR DESCRIPTION
Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=465045
Signed-off-by: Markus Keller <markus_keller@ch.ibm.com>